### PR TITLE
fix for debian jessie, systemd and remote database

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,8 @@ seafile_init_database: False
 seafile_login_host: 'localhost'
 seafile_login_user: 'root'
 seafile_login_user_password: ''
+# instead of using login/pass, use task delegation to login_host
+seafile_delegate_to_login_host: false
 
 # ldap users
 seafile_ldap_enable: False
@@ -58,3 +60,4 @@ seafile_fast_cgi: False
 # list with users to create
 # password is generated and stored under {{ seafile_local_storage_path }}/{{ username }}
 seafile_create_users: []
+

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -9,4 +9,4 @@
   with_items:
   - seafile
   - seahub
- 
+

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,9 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - trusty
+  - name: Debian
+    versions:
+    - jessie
 
   categories:
   - fileserver

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -66,12 +66,6 @@
     mode: 0644
 
 
-- name: provision admin user
-  command: "{{ seafile_installation_path }}/init_admin.sh {{ seafile_admin_email }} {{ seafile_admin_password }}"
-  register: seafile_init_admin
-  when: _seafile_admin_bootstrap.changed
-
-
 - name: create seafile users
   command: "{{ seafile_installation_path }}/create_user.sh {{ item }} {{ lookup('password', seafile_local_storage_path + '/' + item + ' length=18') }}"
   with_items: "{{ seafile_create_users }}"

--- a/tasks/database.yml
+++ b/tasks/database.yml
@@ -8,20 +8,34 @@
     mode: 0400
     
 
-- name: create mysql databases
+- name: create mysql databases (delegate mysql task)
   mysql_db: 
     name: "{{ item }}" 
     state: present
     encoding: utf8
-    login_host: "{{ seafile_mysql_host }}"
-    login_user: "{{ seafile_mysql_user }}"
-    login_password: "{{ seafile_mysql_password }}"
+  delegate_to: "{{ seafile_login_host }}"
   with_items: 
   - "{{ seafile_database_prefix }}ccnet"
   - "{{ seafile_database_prefix }}seafile"
   - "{{ seafile_database_prefix }}seahub" 
   register: __seafile_database_create
-  when: seafile_create_database
+  when: seafile_create_database and seafile_delegate_to_login_host
+
+
+- name: create mysql databases (connect to remote mysql server)
+  mysql_db: 
+    name: "{{ item }}" 
+    state: present
+    encoding: utf8
+    login_host: "{{ seafile_login_host }}"
+    login_user: "{{ seafile_login_user }}"
+    login_password: "{{ seafile_login_user_password }}"
+  with_items: 
+  - "{{ seafile_database_prefix }}ccnet"
+  - "{{ seafile_database_prefix }}seafile"
+  - "{{ seafile_database_prefix }}seahub" 
+  register: __seafile_database_create
+  when: seafile_create_database and not seafile_delegate_to_login_host
 
 
 - name: import initial dump

--- a/tasks/database_user.yml
+++ b/tasks/database_user.yml
@@ -1,11 +1,26 @@
 
 
-
-- name: grant privileges to seafile user
+- name: grant privileges to seafile user (delegate mysql task)
   mysql_user: 
     name: "{{ seafile_mysql_user }}" 
     password: "{{ seafile_mysql_password }}"
-    host: "{{ seafile_mysql_host }}"
+    host: "{{ ansible_default_ipv4.address }}"
+    state: present 
+    priv: "{{ item }}.*:ALL"
+    append_privs: True
+  delegate_to: "{{ seafile_login_host }}"
+  with_items: 
+  - "{{ seafile_database_prefix }}ccnet"
+  - "{{ seafile_database_prefix }}seafile"
+  - "{{ seafile_database_prefix }}seahub" 
+  when: seafile_delegate_to_login_host
+ 
+
+- name: grant privileges to seafile user (connect to remote mysql server)
+  mysql_user: 
+    name: "{{ seafile_mysql_user }}" 
+    password: "{{ seafile_mysql_password }}"
+    host: "{{ ansible_default_ipv4.address }}"
     state: present 
     priv: "{{ item }}.*:ALL"
     login_host: "{{ seafile_login_host }}"
@@ -16,4 +31,5 @@
   - "{{ seafile_database_prefix }}ccnet"
   - "{{ seafile_database_prefix }}seafile"
   - "{{ seafile_database_prefix }}seahub" 
+  when: not seafile_delegate_to_login_host
       

--- a/tasks/download.yml
+++ b/tasks/download.yml
@@ -1,15 +1,16 @@
 
+- name: check installed version
+  stat:
+    path: "{{ seafile_installation_path }}"
+  register: _seafile_installed
+
+
 - name: download seafile
   get_url: 
     url: https://bintray.com/artifact/download/seafile-org/seafile/seafile-server_{{ seafile_version }}_x86-64.tar.gz
     dest: /tmp/
   register: _seafile_download
-
-
-- name: check installed version
-  stat:
-    path: "{{ seafile_installation_path }}"
-  register: _seafile_installed
+  when: _seafile_installed.stat.exists == False
 
 
 - name: unarchive downloaded file

--- a/tasks/init-system.yml
+++ b/tasks/init-system.yml
@@ -1,0 +1,57 @@
+
+# Systemd related configuration
+- name: Install systemd services
+  template: 
+    src: "service-{{ item }}.j2"
+    dest: "/etc/systemd/system/{{ item }}.service"
+  when: ansible_service_mgr == 'systemd'
+  with_items:
+  - seafile
+  - seahub
+
+- name: activate systemd services
+  systemd: 
+    state: started
+    daemon_reload: yes
+    name: "{{ item }}"
+  when: ansible_service_mgr == 'systemd'
+  with_items:
+  - seafile
+  - seahub
+  
+
+# sysvinit related configuration
+- name: link initscripts to init.d
+  file: 
+    src: "{{ seafile_installation_link }}/{{ item }}.sh"
+    dest: "/etc/init.d/{{ item }}"
+    state: link
+  register: __seafile_init_scripts
+  notify:
+  - restart seafile
+  when: ansible_service_mgr != 'systemd'
+  with_items:
+  - seafile
+  - seahub
+
+- name: enable service
+  service:
+    name: "{{ item }}"
+    enabled: True
+  when: __seafile_init_scripts.changed and ansible_service_mgr != 'systemd'
+  with_items:
+  - seafile
+  - seahub
+
+- name: ensure service is running
+  service:
+    name: "{{ item }}"
+    state: started
+  ignore_errors: yes # init script returns non zero when allready running
+  when: ansible_service_mgr != 'systemd'
+  with_items:
+  - seafile
+  - seahub    
+
+
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,6 +45,7 @@
   - "{{ seafile_data_dir }}"
   - "{{ seafile_configuration_path_ccnet }}"
   - "{{ seafile_log_dir }}"
+  - "{{ seafile_pids_path }}"
   
 
 - include: download.yml
@@ -63,7 +64,7 @@
     path: "{{ seafile_home_path }}"
     owner: "{{ seafile_user }}"
     group: "{{ seafile_group }}"
-    recurse: no
+    recurse: yes
   changed_when: False
 
 
@@ -72,35 +73,15 @@
     path: "{{ item }}"
     owner: "{{ seafile_user }}"
     group: "{{ seafile_group }}"
-    mode: 0700
+    mode: 0750
   with_items:
+  - "{{ seafile_home_path }}"
   - "{{ seafile_configuration_path }}"
   - "{{ seafile_configuration_path_ccnet}}"
   - "{{ seafile_data_dir }}"
   - "{{ seafile_log_dir }}"
   - "{{ seafile_pids_path }}"
   
-
-- name: link initscripts to init.d
-  file: 
-    src: "{{ seafile_installation_link }}/{{ item }}.sh"
-    dest: "/etc/init.d/{{ item }}"
-    state: link
-  register: __seafile_init_scripts
-  notify:
-  - restart seafile
-  with_items:
-  - seafile
-  - seahub
-
-- name: enable service
-  service:
-    name: "{{ item }}"
-    enabled: True
-  when: __seafile_init_scripts.changed
-  with_items:
-  - seafile
-  - seahub
 
 - name: logrotate config
   template:
@@ -111,11 +92,12 @@
     mode: 0644
 
 
-- name: ensure service is running
-  service:
-    name: "{{ item }}"
-    state: started
-  ignore_errors: yes # init script returns non zero when allready running
-  with_items:
-  - seafile
-  - seahub    
+- include: init-system.yml
+
+
+- name: provision admin user
+  command: "{{ seafile_installation_path }}/init_admin.sh {{ seafile_admin_email }} {{ seafile_admin_password }}"
+  register: seafile_init_admin
+  when: _seafile_admin_bootstrap.changed
+
+

--- a/tasks/preconfigure.yml
+++ b/tasks/preconfigure.yml
@@ -36,7 +36,7 @@
 
 - name: generate ccnet config
   shell: LD_LIBRARY_PATH={{ seafile_ld_library_path }}:${LD_LIBRARY_PATH}
-         {{ seafile_ccnet_init }} -c {{ seafile_configuration_path }} -H {{ seafile_ip_or_domain }} -n {{seafile_user}} 
+         {{ seafile_ccnet_init }} -c {{ seafile_configuration_path }} -H {{ seafile_ip_or_domain }} -n {{ seafile_user }} 
   when: _seafile_config.stat.exists == False
 
 

--- a/templates/service-seafile.j2
+++ b/templates/service-seafile.j2
@@ -1,0 +1,14 @@
+[Unit]
+Description=Seafile
+After=network.target
+
+[Service]
+Type=oneshot
+ExecStart={{ seafile_home_path }}/current/seafile.sh start
+ExecStop={{ seafile_home_path }}/current/seafile.sh stop
+RemainAfterExit=yes
+User=seafile
+Group=seafile
+
+[Install]
+WantedBy=multi-user.target

--- a/templates/service-seahub.j2
+++ b/templates/service-seahub.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Seafile hub
+After=network.target seafile.service
+
+[Service]
+# change start to start-fastcgi if you want to run fastcgi
+ExecStart={{ seafile_home_path }}/current/seahub.sh start
+ExecStop={{ seafile_home_path }}/current/seahub.sh stop
+User=seafile
+Group=seafile
+Type=oneshot
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Hello,

thanks for your seafile role. I had some trouble with debian jessie and systemd, so I added support for systemd with service files but kept the sysvinit for systems without systemd. 

To better support remote databases (I use a galera 3 node multi master) and remote database creation, I added a delegate option from ansible, that allows the script to create the database on the remote host without connecting from the seafile server to the database with an admin user.

Hopefull to get the request accepted
best regards
Martin